### PR TITLE
Routing Function Added to Codecraft.py

### DIFF
--- a/backend/codecraft.py
+++ b/backend/codecraft.py
@@ -1,6 +1,9 @@
 import requests
 from flask import Flask, request, jsonify
 from flask_cors import CORS
+#AI team will be coding in response.py ( as pushed to the github already )
+#Uncomment the below line when AI team are ready
+#from response.py import default_response
 
 app = Flask(__name__)
 CORS(app)
@@ -21,6 +24,25 @@ def get_joke():
     else:
         # Return an error message if request failed
         return jsonify({'error': 'Failed to fetch joke'}), 500
+    
+
+@app.route('/llm', methods=['POST']) 
+def llm_request():
+    # Get JSON data from the frontend
+    frontend_request_data = request.get_json()
+    # Make API call to LLM
+    #the below line contains a placeholder 'default_response'. Will be removed when AI team is ready
+    llm_response = requests.post('default_response', json=frontend_request_data)  # Replace 'LLM_API_ENDPOINT' with the LLM API endpoint from AI team
+    
+    #if successful return  from LLM
+    if llm_response.status_code == 200:
+        llm_data = llm_response.json()
+        #return response to frontend
+        return jsonify(llm_data) 
+        #if the LLM returns its value as a string, replace the above line with: return llm_data
+    else:
+        #error message:
+        return jsonify({'error': 'Failed to fetch response from LLM'}), 500
 
 if __name__=="__main__":
     app.run(debug=True, port=8080)


### PR DESCRIPTION
According to Abdullah (AI), the LLM will likely be returning its response in a string format There is no current endpoint for the LLM for backend to action Yuchen (frontend) is satisfied if the LLM output is a string. Not much parsing will be required from backend if the LLM output is finalised to be a string. AI team will develop their code in response.py
I cannot test this beyond what the team have already tested with Fionn's "Joke API", until AI team are ready with an endpoint